### PR TITLE
[Vessel] - Autofix finished@1.2.7-multiple-bug

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -66,7 +66,7 @@ int ZEXPORT compress (dest, destLen, source, sourceLen)
     uLong sourceLen;
 {
     int ret = compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
-    ret = ret + 1;
+    
     return ret;
 }
 


### PR DESCRIPTION
# Vessel have completed autofix session. Requesting merge

## Test results of before patch
| Test name | Total test case | Success | Failure |
|-----------|-----------------|---------|---------|
|inflate_test0|74|74|0|
|inflateReset_test0|3|3|0|
|gz_open_test0|44|44|0|
|gzeof_test0|1|1|0|
|gz_error_test0|12|12|0|
|gz_reset_test0|8|8|0|
|gzread_test0|13|13|0|
|gzsetparams_test0|10|10|0|
|compress_test0|3|0|3|
|pqdownheap_test0|6|6|0|
|deflateBound_test0|10|10|0|
|gzclose_r_test0|1|1|0|
|gzungetc_test0|13|13|0|
|gzoffset64_test0|1|1|0|
|inflateBackInit__test0|14|14|0|
|bi_windup_test0|8|8|0|
|gzseek_test0|5|5|0|
|gzwrite_test0|9|9|0|
|adler32_combine64_test0|5|2|3|
|fixedtables_test1|1|1|0|
|putShortMSB_test0|5|5|0|
|crc32_combine__test0|9|9|0|
|gztell64_test0|11|11|0|
|gzgetc__test0|1|1|0|
|deflateSetHeader_test0|7|7|0|
|inflateCopy_test0|1|1|0|
|deflateInit__test0|5|5|0|
|adler32_combine__test0|11|2|9|
|bi_flush_test0|11|11|0|
|compress2_test0|4|4|0|
|gzbuffer_test0|11|11|0|
|inflateResetKeep_test0|3|3|0|
|uncompress_test0|5|5|0|
|gzopen_w_test0|3|3|0|
|gzflush_test0|12|12|0|
|gf2_matrix_times_test0|3|3|0|
|zcalloc_test0|3|3|0|
|gzclose_test0|1|1|0|
|gzoffset_test0|1|1|0|
|gztell_test0|1|1|0|
|zlibVersion_test0|1|1|0|
|gzdopen_test0|9|9|0|
|gzgets_test0|13|13|0|
|crc32_combine_test0|5|5|0|
|gzclearerr_test0|1|1|0|
|gzputs_test0|1|1|0|
|fixedtables_test0|32|32|0|
|inflateInit2__test0|8|8|0|
|inflateInit__test0|5|5|0|
|read_buf_test0|7|7|0|
|gzrewind_test0|12|12|0|
|syncsearch_test0|10|10|0|
|zError_test0|5|5|0|
|inflateMark_test0|1|1|0|
|deflateReset_test0|3|3|0|
|inflateSync_test0|12|12|0|
|inflateGetHeader_test0|1|1|0|
|init_block_test0|14|14|0|
|deflateTune_test0|5|5|0|
|gzseek64_test0|16|16|0|
|inflatePrime_test0|11|11|0|
|zlibCompileFlags_test0|1|1|0|
|gzclose_w_test0|1|1|0|
|compressBound_test0|3|3|0|
|zcfree_test0|1|1|0|
|deflatePending_test0|5|5|0|
|inflateSetDictionary_test0|5|5|0|
|gz_init_test0|5|5|0|
|inflateUndermine_test0|5|5|0|
|inflateBack_test0|46|46|0|
|gzopen64_test0|1|1|0|
|deflateInit2__test0|20|20|0|
|inflateEnd_test0|1|1|0|
|deflateParams_test0|12|12|0|
|gzputc_test0|10|10|0|
|gz_avail_test0|9|9|0|
|deflateResetKeep_test0|5|5|0|
|detect_data_type_test0|19|19|0|
|deflatePrime_test0|7|7|0|
|inflateSyncPoint_test0|1|1|0|
|get_crc_table_test0|1|1|0|
|crc32_combine64_test0|5|5|0|
|gzopen_test0|1|1|0|
|inflateReset2_test0|14|14|0|
|inflateBackEnd_test0|1|1|0|
|adler32_combine_test0|5|2|3|
|gzprintf_test0|1|1|0|
|gzgetc_test0|11|11|0|
|**Total**|717|699|18|

## Suspicious codes


----
Clicking on the link, you take the page with code highlighted.
Here is most suspicious code piece.Recommend debugging here.
Click below the collapsed section for more information.

<details><summary>Click here to extend</summary>

Suspicious score: 1
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/adler32.c#L156

Suspicious score: 0.17647058823529413
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/adler32.c#L171

Suspicious score: 0.17647058823529413
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/adler32.c#L179

</details>


<details><summary>Click here to extend</summary>

Suspicious score: 0.2307692307692308
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/zutil.c#L311

Suspicious score: 0.2727272727272727
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/zutil.c#L318

Suspicious score: -1
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L311

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L387

Suspicious score: 0.15789473684210523
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L415

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L470

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L515

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L580

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L665

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L736

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L824

Suspicious score: 0.4
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L885

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L928

Suspicious score: 0.3333333333333333
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L1073

Suspicious score: 0.05
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L1131

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L1159

Suspicious score: 0.13333333333333333
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L1174

Suspicious score: 0.16666666666666666
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/trees.c#L1190

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/compress.c#L49

Suspicious score: 1
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/compress.c#L68

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/adler32.c#L90

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L207

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L288

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L410

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L434

Suspicious score: 0.2
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L631

Suspicious score: 0.4
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L644

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L681

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L984

Suspicious score: 0.25
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L1088

Suspicious score: 0.6
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L1109

Suspicious score: 0.3333333333333333
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L1492

Suspicious score: 0.3333333333333333
https://github.com/0cherry/AutoDebugging-zlib-mirror/blob/739e2b74445324f1cf8365d3d205c9f573d19fae/deflate.c#L1743

</details>

## Test results of after patch
| Test name | Total test case | Success | Failure |
|-----------|-----------------|---------|---------|
|deflateReset_test0|3|3|0|
|gzwrite_test0|9|9|0|
|gzopen64_test0|1|1|0|
|adler32_combine64_test0|5|2|3|
|gzputc_test0|10|10|0|
|inflateCopy_test0|1|1|0|
|gz_reset_test0|8|8|0|
|deflateSetHeader_test0|7|7|0|
|deflateParams_test0|12|12|0|
|inflateReset_test0|3|3|0|
|read_buf_test0|7|7|0|
|pqdownheap_test0|6|6|0|
|bi_flush_test0|11|11|0|
|gzclose_w_test0|1|1|0|
|compressBound_test0|3|3|0|
|gzoffset_test0|1|1|0|
|gzprintf_test0|1|1|0|
|detect_data_type_test0|19|19|0|
|uncompress_test0|5|5|0|
|gz_open_test0|44|44|0|
|gz_error_test0|12|12|0|
|inflatePrime_test0|11|11|0|
|gzbuffer_test0|11|11|0|
|crc32_combine__test0|9|9|0|
|zcalloc_test0|3|3|0|
|gztell64_test0|11|11|0|
|init_block_test0|14|14|0|
|crc32_combine_test0|5|5|0|
|deflateInit2__test0|20|20|0|
|deflateResetKeep_test0|5|5|0|
|inflateBackEnd_test0|1|1|0|
|get_crc_table_test0|1|1|0|
|gzclearerr_test0|1|1|0|
|inflate_test0|74|74|0|
|inflateBackInit__test0|14|14|0|
|gz_init_test0|5|5|0|
|inflateSetDictionary_test0|5|5|0|
|compress_test0|3|3|0|
|gzgetc_test0|11|11|0|
|deflateTune_test0|5|5|0|
|gztell_test0|1|1|0|
|gzseek_test0|5|5|0|
|gzputs_test0|1|1|0|
|gzclose_test0|1|1|0|
|inflateGetHeader_test0|1|1|0|
|gzgetc__test0|1|1|0|
|gzeof_test0|1|1|0|
|zlibCompileFlags_test0|1|1|0|
|putShortMSB_test0|5|5|0|
|gzsetparams_test0|10|10|0|
|deflateInit__test0|5|5|0|
|inflateResetKeep_test0|3|3|0|
|adler32_combine_test0|5|2|3|
|crc32_combine64_test0|5|5|0|
|gz_avail_test0|9|9|0|
|zError_test0|5|5|0|
|gzopen_w_test0|3|3|0|
|fixedtables_test1|1|1|0|
|inflateBack_test0|46|46|0|
|syncsearch_test0|10|10|0|
|gzdopen_test0|9|9|0|
|inflateSyncPoint_test0|1|1|0|
|deflateBound_test0|10|10|0|
|compress2_test0|4|4|0|
|gzseek64_test0|16|16|0|
|inflateReset2_test0|14|14|0|
|inflateSync_test0|12|12|0|
|inflateUndermine_test0|5|5|0|
|inflateMark_test0|1|1|0|
|gzungetc_test0|13|13|0|
|bi_windup_test0|8|8|0|
|adler32_combine__test0|11|2|9|
|gzopen_test0|1|1|0|
|inflateEnd_test0|1|1|0|
|zlibVersion_test0|1|1|0|
|gzoffset64_test0|1|1|0|
|zcfree_test0|1|1|0|
|deflatePrime_test0|7|7|0|
|gf2_matrix_times_test0|3|3|0|
|gzrewind_test0|12|12|0|
|deflatePending_test0|5|5|0|
|gzgets_test0|13|13|0|
|gzclose_r_test0|1|1|0|
|fixedtables_test0|32|32|0|
|gzflush_test0|12|12|0|
|inflateInit2__test0|8|8|0|
|gzread_test0|13|13|0|
|inflateInit__test0|5|5|0|
|**Total**|717|702|15|
